### PR TITLE
Introduced the ability to provide own client for spark streaming

### DIFF
--- a/core/src/main/scala/jp/co/bizreach/kinesis/AmazonKinesis.scala
+++ b/core/src/main/scala/jp/co/bizreach/kinesis/AmazonKinesis.scala
@@ -2,8 +2,9 @@ package jp.co.bizreach.kinesis
 
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
 import com.amazonaws.regions.Regions
-import com.amazonaws.services.kinesis.{AmazonKinesis => AWSKinesis, AmazonKinesisClientBuilder}
+import com.amazonaws.services.kinesis.{AmazonKinesisClientBuilder, AmazonKinesis => AWSKinesis}
 import jp.co.bizreach.kinesis.action.PutRecordAction
 
 object AmazonKinesis {
@@ -18,9 +19,22 @@ object AmazonKinesis {
       .withRegion(region)
       .build()) with PutRecordAction
   }
+  def apply(endpointConfiguration: EndpointConfiguration)(implicit region: Regions): AmazonKinesis = {
+    new AmazonKinesis(AmazonKinesisClientBuilder.standard
+      .withEndpointConfiguration(endpointConfiguration)
+      .withRegion(region)
+      .build()) with PutRecordAction
+  }
   def apply(config: ClientConfiguration)(implicit region: Regions): AmazonKinesis = {
     new AmazonKinesis(AmazonKinesisClientBuilder.standard
       .withClientConfiguration(config)
+      .withRegion(region)
+      .build()) with PutRecordAction
+  }
+  def apply(config: ClientConfiguration, endpointConfiguration: EndpointConfiguration)(implicit region: Regions): AmazonKinesis = {
+    new AmazonKinesis(AmazonKinesisClientBuilder.standard
+      .withClientConfiguration(config)
+      .withEndpointConfiguration(endpointConfiguration)
       .withRegion(region)
       .build()) with PutRecordAction
   }
@@ -28,6 +42,14 @@ object AmazonKinesis {
     new AmazonKinesis(AmazonKinesisClientBuilder.standard
       .withCredentials(credentials)
       .withClientConfiguration(config)
+      .withRegion(region)
+      .build()) with PutRecordAction
+  }
+  def apply(credentials: AWSCredentialsProvider, config: ClientConfiguration, endpointConfiguration: EndpointConfiguration)(implicit region: Regions): AmazonKinesis = {
+    new AmazonKinesis(AmazonKinesisClientBuilder.standard
+      .withCredentials(credentials)
+      .withClientConfiguration(config)
+      .withEndpointConfiguration(endpointConfiguration)
       .withRegion(region)
       .build()) with PutRecordAction
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "1.0.0")
-
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
+addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "1.0.0")
 

--- a/spark/src/main/scala/jp/co/bizreach/kinesis/spark/package.scala
+++ b/spark/src/main/scala/jp/co/bizreach/kinesis/spark/package.scala
@@ -1,6 +1,7 @@
 package jp.co.bizreach.kinesis
 
-import com.amazonaws.auth.{DefaultAWSCredentialsProviderChain, AWSCredentialsProvider}
+import com.amazonaws.auth.{AWSCredentialsProvider, DefaultAWSCredentialsProviderChain}
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
 import com.amazonaws.regions.Regions
 import org.apache.spark.rdd.RDD
 
@@ -21,9 +22,10 @@ package object spark {
      */
     def saveToKinesis(streamName: String, region: Regions,
                       credentials: Class[_ <: AWSCredentialsProvider] = classOf[DefaultAWSCredentialsProviderChain],
-                      chunk: Int = recordsMaxCount): Unit =
+                      chunk: Int = recordsMaxCount,
+                      client: Option[AmazonKinesis] = Option.empty): Unit =
       if (!rdd.isEmpty) rdd.sparkContext.runJob(rdd,
-        new KinesisRDDWriter(streamName, region, credentials, chunk).write)
+        new KinesisRDDWriter(streamName, region, credentials, chunk, client).write)
   }
 
 }


### PR DESCRIPTION
 I have the need to test this stuff locally, so the ability to provide own client is crucial.

A good usage example would be setting custom endpoint.