### PR TITLE
Scala 2.13 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: scala
 
 jdk:
-  - oraclejdk8
+  - openjdk8
+  - openjdk11
 
 env:
   global:

--- a/build.sbt
+++ b/build.sbt
@@ -58,17 +58,18 @@ lazy val root = (project in file("."))
     packagedArtifacts := Map.empty
   )
 
-val sdkVersion = "1.11.550"
+val sdkVersion = "1.11.579"
 val sparkVersion = "2.4.3"
 
 lazy val core = project
   .settings(commonSettings: _*)
   .settings(
     name := "aws-kinesis-scala",
+    crossScalaVersions += "2.13.0",
     libraryDependencies ++= Seq(
       "com.amazonaws" %  "aws-java-sdk-kinesis" % sdkVersion,
       "org.slf4j"     %  "slf4j-api"            % "1.7.26",
-      "org.scalatest" %% "scalatest"            % "3.0.7" % "test"
+      "org.scalatest" %% "scalatest"            % "3.0.8" % "test"
     )
   )
 

--- a/core/src/main/scala/jp/co/bizreach/kinesis/package.scala
+++ b/core/src/main/scala/jp/co/bizreach/kinesis/package.scala
@@ -46,6 +46,10 @@ package object kinesis {
   val BufferedAmazonKinesisClient = BufferedAmazonKinesis
 
 
+  private[this] implicit class JListConverters[A](list: java.util.List[A]) {
+    def immutableSeq: Seq[A] = list.asScala.toSeq
+  }
+
   case class AddTagsToStreamRequest(streamName: String,
                                     tags: Map[String, String],
                                     requestMetricCollector: Option[RequestMetricCollector] = None)
@@ -108,7 +112,7 @@ package object kinesis {
         streamName = result.getStreamDescription.getStreamName,
         streamARN = result.getStreamDescription.getStreamARN,
         streamStatus = result.getStreamDescription.getStreamStatus,
-        shards = result.getStreamDescription.getShards.asScala.map { shard =>
+        shards = result.getStreamDescription.getShards.immutableSeq.map { shard =>
           Shard(
             shardId = shard.getShardId,
             parentShardId = shard.getParentShardId,
@@ -147,7 +151,7 @@ package object kinesis {
 
   implicit def convertGetRecordsResult(result: AWSGetRecordsResult): GetRecordsResult = {
     GetRecordsResult(
-      records = result.getRecords.asScala.map { record =>
+      records = result.getRecords.immutableSeq.map { record =>
         Record(
           data           = record.getData.array(),
           sequenceNumber = record.getSequenceNumber,
@@ -197,7 +201,7 @@ package object kinesis {
 
   implicit def convertListStreamsResult(request: AWSListStreamsResult): ListStreamsResult = {
     ListStreamsResult(
-      streamNames = request.getStreamNames.asScala,
+      streamNames = request.getStreamNames.immutableSeq,
       hasMoreStreams = request.getHasMoreStreams
     )
   }
@@ -223,7 +227,7 @@ package object kinesis {
 
   implicit def convertListTagsForStreamResult(result: AWSListTagsForStreamResult): ListTagsForStreamResult = {
     ListTagsForStreamResult(
-      tags = result.getTags.asScala.map { tag =>
+      tags = result.getTags.immutableSeq.map { tag =>
         Tag(key = tag.getKey, value = tag.getValue)
       },
       hasMoreTags = result.getHasMoreTags
@@ -305,7 +309,7 @@ package object kinesis {
   implicit def convertPutRecordsResult(result: AWSPutRecordsResult): PutRecordsResult = {
     PutRecordsResult(
       failedRecordCount = result.getFailedRecordCount,
-      records = result.getRecords.asScala.map { record =>
+      records = result.getRecords.immutableSeq.map { record =>
         PutRecordsResultEntry(
           sequenceNumber = record.getSequenceNumber,
           shardId = record.getShardId,

--- a/core/src/main/scala/jp/co/bizreach/kinesisfirehose/package.scala
+++ b/core/src/main/scala/jp/co/bizreach/kinesisfirehose/package.scala
@@ -14,6 +14,10 @@ import scala.language.implicitConversions
 
 package object kinesisfirehose {
 
+  private[this] implicit class JListConverters[A](list: java.util.List[A]) {
+    def immutableSeq: Seq[A] = list.asScala.toSeq
+  }
+
   case class PutRecordRequest(deliveryStreamName: String, record: Array[Byte])
 
   implicit def convertPutRecordRequest(request: PutRecordRequest): AWSPutRecordRequest = {
@@ -48,7 +52,7 @@ package object kinesisfirehose {
   implicit def convertPutRecordBatchResult(result: AWSPutRecordBatchResult): PutRecordBatchResult = {
     PutRecordBatchResult(
       failedPutCount = result.getFailedPutCount,
-      records = result.getRequestResponses.asScala.map { record =>
+      records = result.getRequestResponses.immutableSeq.map { record =>
         PutRecordBatchResponseEntry(
           recordId = record.getRecordId,
           errorCode = record.getErrorCode,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")


### PR DESCRIPTION
Spark hasn't supported Scala 2.13 yet, so this change enables 2.12 compilation for core module only.