### PR TITLE
add the possibility of adding a custom partitionKey

### DIFF
--- a/spark/src/main/scala/jp/co/bizreach/kinesis/spark/package.scala
+++ b/spark/src/main/scala/jp/co/bizreach/kinesis/spark/package.scala
@@ -20,9 +20,10 @@ package object spark {
     def saveToKinesis(streamName: String, region: Regions,
                       credentials: SparkAWSCredentials = DefaultCredentials,
                       chunk: Int = recordsMaxCount,
-                      endpoint: Option[String] = None): Unit =
+                      endpoint: Option[String] = None,
+                      partitionKeyFunction: Option[A => String] = None): Unit =
       if (!rdd.isEmpty) rdd.sparkContext.runJob(rdd,
-        new KinesisRDDWriter(streamName, region, credentials, chunk, endpoint).write _)
+        new KinesisRDDWriter(streamName, region, credentials, chunk, endpoint, partitionKeyFunction).write _)
   }
 
 }


### PR DESCRIPTION
Aim is to add the possibility of adding a custom partitionKey instead of a hashed value from the record. This way sequence can be kept for certain records in kinesis, because they end up on the same shard.